### PR TITLE
feat: add github pages deploy config to docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,20 +8,18 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'My Site',
-  tagline: 'Dinosaurs are cool',
+  title: 'SSLASH',
+  tagline: 'Find your texts, urls and commands easly',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://shakg.github.io/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
-
-  // GitHub pages deployment config.
-  // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  baseUrl: "/sslash-landing-page/",
+  projectName: 'sslash-landing-page',
+  organizationName: 'shakg',
+  trailingSlash: false,
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
## Changes;
 - add github pages deploy config to docusaurus config
 
## Results;
 - developers will change documentation and simply run `npm run deploy` to publish this docs site.